### PR TITLE
data: parse Fan data

### DIFF
--- a/pyhealthbox3/models.py
+++ b/pyhealthbox3/models.py
@@ -188,6 +188,24 @@ class Healthbox3WIFIConnectionDataObject:
         self.connection_error = connection_error
 
 
+class Healthbox3FanDataObject:
+    """Healthbox3 Fan Data Object."""
+
+    voltage: float = None
+    pressure: float = None
+    flow: float = None
+    power: float = None
+    rpm: int = None
+
+    def __init__(self, voltage: float = None, pressure: float = None, flow: float = None, power: float = None, rpm: int = None) -> None:
+
+        self.voltage = voltage
+        self.pressure = pressure
+        self.flow = flow
+        self.power = power
+        self.rpm = rpm
+
+
 
 class Healthbox3DataObject:
     """Healthbox3 Data Object."""
@@ -204,6 +222,8 @@ class Healthbox3DataObject:
     rooms: list[Healthbox3Room]
 
     wifi: Healthbox3WIFIConnectionDataObject = Healthbox3WIFIConnectionDataObject()
+
+    fan: Healthbox3FanDataObject = Healthbox3FanDataObject()
 
     def __init__(self, data: any, advanced_features: bool = False) -> None:
         """Initialize."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyhealthbox3"
-version = "0.0.20"
+version = "0.0.21"
 authors = [
   { name="rmassch", email="1083135+rmassch@users.noreply.github.com" },
 ]


### PR DESCRIPTION
In /v2/device, there is a 'fan' section with a few info, e.g.

```
  {
    "voltage": 2.3120000000000003,
    "pressure": 16.033831993094875,
    "flow": 97.989253893208,
    "power": 3.8216333353915815,
    "rpm": 420
  }
```

Looks good to expose them.

(Note: currently untested, but looks OK)